### PR TITLE
Fix unsubscribe_client_context_change exception

### DIFF
--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -12,6 +12,11 @@ Release Notes
 
     .. change:: fixed
 
+        Fix unsubscribe_client_context_change exception.
+
+
+    .. change:: fixed
+
         Fixed bug were Nuke log viewer and documentation was not working.
 
 

--- a/source/ftrack_connect_pipeline_nuke/client/asset_manager.py
+++ b/source/ftrack_connect_pipeline_nuke/client/asset_manager.py
@@ -32,4 +32,4 @@ class NukeQtAssetManagerClientWidget(QtAssetManagerClientWidget):
         super(NukeQtAssetManagerClientWidget, self).hideEvent(*args, **kwargs)
         self.logger.debug('closing qt client')
         # Unsubscribe to context change events
-        self.unsubscribe_client_context_change()
+        self.unsubscribe_host_context_change()

--- a/source/ftrack_connect_pipeline_nuke/client/publish.py
+++ b/source/ftrack_connect_pipeline_nuke/client/publish.py
@@ -28,4 +28,4 @@ class NukeQtPublisherClientWidget(QtPublisherClientWidget):
         super(NukeQtPublisherClientWidget, self).hideEvent(*args, **kwargs)
         self.logger.debug('closing qt client')
         # Unsubscribe to context change events
-        self.unsubscribe_client_context_change()
+        self.unsubscribe_host_context_change()


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-3mek9xn

- [X] The PR contains update to the release notes.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [X] Linux.


## Changes

Fixed bug where an invalid call to unsubscribe_client_context_change was made in the widget hide

## Test

Open Maya and open+close Publisher client, no exception should be thrown in console
            