### PR TITLE
fix: Fixed conversion of asset info objects loaded and latest version to boolean

### DIFF
--- a/resource/plugins/python/publisher/collectors/widget/nuke_movie_publisher_collector_options.py
+++ b/resource/plugins/python/publisher/collectors/widget/nuke_movie_publisher_collector_options.py
@@ -395,7 +395,7 @@ class NukeMoviePublisherCollectorOptionsWidget(BaseOptionsWidget):
         '''(Override) Amount of collected objects has changed, notify parent(s)'''
         status = False
         if self._render_rb.isChecked():
-            if self._nodes_cb.isEnabled() :
+            if self._nodes_cb.isEnabled():
                 message = '1 script node selected'
                 status = True
             else:

--- a/source/ftrack_connect_pipeline_nuke/asset/dcc_object.py
+++ b/source/ftrack_connect_pipeline_nuke/asset/dcc_object.py
@@ -144,6 +144,11 @@ class NukeDccObject(DccObject):
                     for dep_id in (knob.getValue() or '').split(','):
                         if len(dep_id) > 0:
                             param_dict[knob.name()].append(dep_id)
+                elif knob.name() in [
+                    asset_const.OBJECTS_LOADED,
+                    asset_const.IS_LATEST_VERSION,
+                ]:
+                    param_dict[knob.name()] = bool(knob.getValue())
                 else:
                     param_dict[knob.name()] = knob.getValue()
 


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
  
  * CLICKUP-865bx1u8q
  * FT-
  * SENTRY-
  * ZENDESK-

-->

Resolves <!--Task reference -->

## Changes

Fixed conversion of asset info objects loaded and latest version to boolean

## Test

Test AM, objects loaded was set to string value of "True", should be proper boolean now
