### PR TITLE
fix: Nuke non padded image sequence load bug

### DIFF
--- a/resource/plugins/python/loader/importers/nuke_sequence_loader_importer.py
+++ b/resource/plugins/python/loader/importers/nuke_sequence_loader_importer.py
@@ -4,9 +4,9 @@ import os
 import traceback
 import clique
 
-import ftrack_api
-
 import nuke
+
+import ftrack_api
 
 from ftrack_connect_pipeline_nuke import plugin
 from ftrack_connect_pipeline_nuke import utils as nuke_utils
@@ -37,7 +37,7 @@ class NukeSequenceLoaderImporterPlugin(plugin.NukeLoaderImporterPlugin):
 
             resulting_node['file'].fromUserText(component_path)
             # Detect frame range based on files on disk (safe)
-            if component_path.find('%0') > 0:
+            if component_path.find('%') > 0:
                 try:
                     directory, filename = os.path.split(component_path)
                     self.logger.debug(
@@ -46,7 +46,7 @@ class NukeSequenceLoaderImporterPlugin(plugin.NukeLoaderImporterPlugin):
                         )
                     )
                     if os.path.exists(directory):
-                        split_pos = filename.find('%')
+                        split_pos = filename.rfind('%')
                         prefix = filename[:split_pos]
                         suffix = filename[filename.find('d', split_pos) + 1 :]
                         files = []

--- a/resource/plugins/python/publisher/collectors/nuke_sequence_publisher_collector.py
+++ b/resource/plugins/python/publisher/collectors/nuke_sequence_publisher_collector.py
@@ -17,9 +17,29 @@ class NukeSequencePublisherCollectorPlugin(
     plugin_name = 'nuke_sequence_publisher_collector'
 
     supported_file_formats = [
-        ".cin", ".dng", ".dpx", ".dtex", ".gif", ".bmp", ".float", ".pcx",
-        ".png", ".psd", ".tga", ".jpeg", ".jpg", ".exr", ".dds", ".hdr",
-        ".hdri", ".cgi", ".tif", ".tiff", ".tga", ".targa", ".yuv",
+        ".cin",
+        ".dng",
+        ".dpx",
+        ".dtex",
+        ".gif",
+        ".bmp",
+        ".float",
+        ".pcx",
+        ".png",
+        ".psd",
+        ".tga",
+        ".jpeg",
+        ".jpg",
+        ".exr",
+        ".dds",
+        ".hdr",
+        ".hdri",
+        ".cgi",
+        ".tif",
+        ".tiff",
+        ".tga",
+        ".targa",
+        ".yuv",
     ]
 
     def fetch(self, context_data=None, data=None, options=None):

--- a/resource/plugins/python/publisher/collectors/widget/nuke_movie_publisher_collector_options.py
+++ b/resource/plugins/python/publisher/collectors/widget/nuke_movie_publisher_collector_options.py
@@ -192,7 +192,7 @@ class NukeMoviePublisherCollectorOptionsWidget(BaseOptionsWidget):
             )  # Set default mode
 
     def post_build(self):
-        ''' Connect signals'''
+        '''Connect signals'''
         super(NukeMoviePublisherCollectorOptionsWidget, self).post_build()
 
         self._nodes_cb.text_changed.connect(self._on_node_selected)
@@ -214,11 +214,11 @@ class NukeMoviePublisherCollectorOptionsWidget(BaseOptionsWidget):
         self.rbg.set_default(self.options['mode'].lower())
 
     def refresh_nodes(self):
-        ''' Run fetch function '''
+        '''Run fetch function'''
         self.on_run_plugin(method="fetch")
 
     def set_mode(self, mode_name, widget, inner_widget):
-        ''' Set up the mode of the widget '''
+        '''Set up the mode of the widget'''
         self.set_option_result(mode_name, 'mode')
         if inner_widget in [self._nodes_cb, self._write_nodes_cb]:
             self._on_node_selected(inner_widget.get_text())

--- a/resource/plugins/python/publisher/collectors/widget/nuke_sequence_publisher_collector_options.py
+++ b/resource/plugins/python/publisher/collectors/widget/nuke_sequence_publisher_collector_options.py
@@ -150,7 +150,7 @@ class NukeSequencePublisherCollectorOptionsWidget(BaseOptionsWidget):
             )  # Set default mode
 
     def post_build(self):
-        ''' Connect signals'''
+        '''Connect signals'''
         super(NukeSequencePublisherCollectorOptionsWidget, self).post_build()
 
         self._nodes_cb.text_changed.connect(self._on_node_selected)
@@ -168,14 +168,14 @@ class NukeSequencePublisherCollectorOptionsWidget(BaseOptionsWidget):
         self.rbg.set_default(self.options['mode'].lower())
 
     def refresh_nodes(self):
-        ''' Run fetch function '''
+        '''Run fetch function'''
         self.on_run_plugin(method="fetch")
         name, widget, inner_widget = self.rbg.get_checked_button()
         if name:
             self.set_mode(name, widget, inner_widget)
 
     def set_mode(self, mode_name, widget, inner_widget):
-        ''' Set up the mode of the widget '''
+        '''Set up the mode of the widget'''
         self.set_option_result(mode_name, 'mode')
         if inner_widget in [self._nodes_cb, self._write_nodes_cb]:
             self._on_node_selected(inner_widget.get_text())

--- a/resource/plugins/python/publisher/exporters/nuke_sequence_publisher_exporter.py
+++ b/resource/plugins/python/publisher/exporters/nuke_sequence_publisher_exporter.py
@@ -20,7 +20,6 @@ class NukeSequencePublisherExporterPlugin(plugin.NukePublisherExporterPlugin):
 
     def run(self, context_data=None, data=None, options=None):
         '''Export an image sequence from Nuke from collected node or supplied media with *data* based on *options*'''
-
         node_name = None
         image_sequence_path = None
         create_write = False


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
  
  * CLICKUP-865c1d5y2

-->

Resolves <!--Task reference -->

## Changes

Nuke now supports proper load of image sequences having no frame number padding (frame.1.exr, ... , frame.10.exr,...)

## Test

